### PR TITLE
Change directives to new format "data-wp-directive.event`

### DIFF
--- a/src/blocks/interactive/likes-number/render.php
+++ b/src/blocks/interactive/likes-number/render.php
@@ -20,10 +20,9 @@ store(
 );
 ?>
 
-<div
+<div 
 	<?php echo $wrapper_attributes; ?>
-	wp-class:wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty"
->
+	data-wp-class.wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty">
 	<?php echo $play_icon; ?>
-	<span wp-text="selectors.wpmovies.likesCount"></span>
+	<span data-wp-text="selectors.wpmovies.likesCount"></span>
 </div>

--- a/src/blocks/interactive/movie-genres/render.php
+++ b/src/blocks/interactive/movie-genres/render.php
@@ -6,13 +6,13 @@ $wrapper_attributes = get_block_wrapper_attributes();
 <div <?php echo $wrapper_attributes; ?>>
 	<?php if ( count( wp_get_post_categories( $post->ID ) ) !== 0 ) {
 		foreach ( wp_get_post_categories( $post->ID ) as $category_id ) {
-			?>
+	?>
 			<a
-				wp-link="{ \'prefetch\': true }"
+				data-wp-link="{ \'prefetch\': true }"
 				href="<?php echo get_category_link( $category_id ); ?>"
 			>
 				<?php echo get_cat_name( $category_id ); ?>
 			</a>
-		<?php }
+	<?php }
 	} ?>
 </div>

--- a/src/blocks/interactive/movie-like-button/render.php
+++ b/src/blocks/interactive/movie-like-button/render.php
@@ -16,15 +16,15 @@ store(
 
 <div
 	<?php echo $wrapper_attributes; ?>
-	wp-context='{ "post": { "id": <?php echo $post->ID; ?> } }'
+	data-wp-context='{ "post": { "id": <?php echo $post->ID; ?> } }'
 >
 	<div
 		class="wpmovies-page-button-parent"
-		wp-on:click="actions.wpmovies.toggleMovie"
+		data-wp-on.click="actions.wpmovies.toggleMovie"
 	>
 		<div
 			class="wpmovies-page-button-child"
-			wp-class:wpmovies-liked="selectors.wpmovies.isMovieIncluded"
+			data-wp-class.wpmovies-liked="selectors.wpmovies.isMovieIncluded"
 		>
 			<?php echo $play_icon; ?>
 			<span>

--- a/src/blocks/interactive/movie-like-icon/render.php
+++ b/src/blocks/interactive/movie-like-icon/render.php
@@ -16,11 +16,11 @@ store(
 
 <div
 	<?php echo $wrapper_attributes; ?>
-	wp-context='{ "post": { "id": <?php echo $post->ID; ?> } }'
+	data-wp-context='{ "post": { "id": <?php echo $post->ID; ?> } }'
 >
 	<div
-		wp-on:click="actions.wpmovies.toggleMovie"
-		wp-class:wpmovies-liked="selectors.wpmovies.isMovieIncluded"
+		data-wp-on.click="actions.wpmovies.toggleMovie"
+		data-wp-class.wpmovies-liked="selectors.wpmovies.isMovieIncluded"
 	>
 		<?php echo $play_icon; ?>
 	</div>

--- a/src/blocks/interactive/movie-search/render.php
+++ b/src/blocks/interactive/movie-search/render.php
@@ -15,13 +15,13 @@ store(
 ?>
 
 <div <?php echo $wrapper_attributes; ?>>
-	<input 
-	  type="search" 
-	  name="s" 
-	  inputmode="search" 
-	  placeholder="Search for a movie..." 
-		required="" 
-		wp-bind:value="state.wpmovies.searchValue" 
-		wp-on:input="actions.wpmovies.updateSearch"
+	<input
+		type="search"
+		name="s"
+		inputmode="search"
+		placeholder="Search for a movie..."
+		required=""
+		data-wp-bind.value="state.wpmovies.searchValue"
+		data-wp-on.input="actions.wpmovies.updateSearch"
 	>
 </div>

--- a/src/blocks/interactive/movie-tabs/render.php
+++ b/src/blocks/interactive/movie-tabs/render.php
@@ -18,55 +18,55 @@ store(
 );
 ?>
 
-<div 
+<div
 	<?php echo $wrapper_attributes; ?>
-	wp-context='{ "tab": "images" }'
+	data-wp-context='{ "tab": "images" }'
 >
 	<ul>
 		<li
-			wp-on:click="actions.wpmovies.showImagesTab"
-			wp-class:wpmovies-active-tab="selectors.wpmovies.isImagesTab"
+			data-wp-on.click="actions.wpmovies.showImagesTab"
+			data-wp-class.wpmovies-active-tab="selectors.wpmovies.isImagesTab"
 			class="wpmovies-tabs-title"
 		>
-				Images
-			</li>
+			Images
+		</li>
 		<li
-			wp-on:click="actions.wpmovies.showVideosTab"
-			wp-class:wpmovies-active-tab="selectors.wpmovies.isVideosTab"
+			data-wp-on.click="actions.wpmovies.showVideosTab"
+			data-wp-class.wpmovies-active-tab="selectors.wpmovies.isVideosTab"
 			class=" wpmovies-tabs-title"
 		>
-				Videos
-			</li>
+			Videos
+		</li>
 	</ul>
-	
-	<div wp-show="selectors.wpmovies.isImagesTab">
+
+	<div data-wp-show="selectors.wpmovies.isImagesTab">
 		<div class="wpmovies-media-scroller wpmovies-images-tab">
 			<?php
 			foreach ( json_decode( $images, true ) as $image_id ) {
 				$image_url = wp_get_attachment_image_url( $image_id, '' );
-				?>
+			?>
 				<img src="<?php echo $image_url; ?>">
-				<?php
+			<?php
 			}
 			?>
 		</div>
 	</div>
 
-	<div wp-show="selectors.wpmovies.isVideosTab">
+	<div data-wp-show="selectors.wpmovies.isVideosTab">
 		<div class="wpmovies-media-scroller wpmovies-videos-tab">
 			<?php
 			foreach ( json_decode( $videos, true ) as $video ) {
 				$video_id = substr( $video['url'], strpos( $video['url'], '?v=' ) + 3 );
-				?>
-				<div class="wpmovies-tabs-video-wrapper" wp-context='{ "videoId": "<?php echo $video_id; ?>" }'>
-					<div wp-on:click="actions.wpmovies.setVideo">
+			?>
+				<div class="wpmovies-tabs-video-wrapper" data-wp-context='{ "videoId": "<?php echo $video_id; ?>" }'>
+					<div data-wp-on.click="actions.wpmovies.setVideo">
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ffffff" class="play-icon">
 							<path d="M3 22v-20l18 10-18 10z" />
 						</svg>
 					</div>
 					<img src="<?php echo 'https://img.youtube.com/vi/' . $video_id . '/0.jpg'; ?>">
 				</div>
-				<?php
+			<?php
 			}
 			?>
 		</div>

--- a/src/blocks/interactive/movie-trailer-button/render.php
+++ b/src/blocks/interactive/movie-trailer-button/render.php
@@ -15,12 +15,12 @@ if ( count( $trailers ) !== 0 ) {
 	$trailer_id  = substr( $trailer_url, strpos( $trailer_url, '?v=' ) + 3 );
 ?>
 
-<div <?php echo $wrapper_attributes; ?> wp-context='{ "videoId": "<?php echo $trailer_id; ?>" }'>
-	<div class="wpmovies-page-button-parent" wp-on:click="actions.wpmovies.setVideo">
-		<div class="wpmovies-page-button-child">
-			<?php echo $play_icon; ?><span>Play trailer</span>
+	<div <?php echo $wrapper_attributes; ?> data-wp-context='{ "videoId": "<?php echo $trailer_id; ?>" }'>
+		<div class="wpmovies-page-button-parent" data-wp-on.click="actions.wpmovies.setVideo">
+			<div class="wpmovies-page-button-child">
+				<?php echo $play_icon; ?><span>Play trailer</span>
+			</div>
 		</div>
 	</div>
-</div>
 
 <?php } ?>

--- a/src/blocks/interactive/video-player/render.php
+++ b/src/blocks/interactive/video-player/render.php
@@ -19,19 +19,19 @@ store(
 );
 ?>
 
-<div wp-show="selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>
+<div data-wp-show="selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>
 	<div class="wpmovies-video-wrapper">
 		<div class="wpmovies-video-close">
-			<button class="close-button" wp-on:click="actions.wpmovies.closeVideo">
+			<button class="close-button" data-wp-on.click="actions.wpmovies.closeVideo">
 				<?php _e( 'Close' ); ?>
 			</button>
 		</div>
 		<iframe
-			width="420" 
-			height="315" 
+			width="420"
+			height="315"
 			allow="autoplay"
 			allowfullscreen
-			wp-bind:src="state.wpmovies.currentVideo"
+			data-wp-bind.src="state.wpmovies.currentVideo"
 		></iframe>
 	</div>
 </div>


### PR DESCRIPTION
EDIT: ~~Note: Right now, the `wp-text` directive breaks the page until [this](https://github.com/WordPress/block-interactivity-experiments/pull/188) is solved.~~ Merged now

Based on the decisions made here https://github.com/WordPress/block-interactivity-experiments/issues/132#issuecomment-1466738441, we changed the format of the directives (https://github.com/WordPress/block-interactivity-experiments/pull/181 & https://github.com/WordPress/block-interactivity-experiments/pull/184).

I'm opening this pull request to adapt the movies demo's code to that format and make it work with the latest version of the block-interactivity-experiments.