### PR TITLE
Rename `store` to `wp_store` in PHP files

### DIFF
--- a/docs/interactive-blocks/README.md
+++ b/docs/interactive-blocks/README.md
@@ -11,7 +11,7 @@ $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 $likedMovies        = array();
 
-store(
+wp_store(
 	array(
 		'state' => array(
 			'wpmovies' => array(
@@ -73,7 +73,7 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-store(
+wp_store(
 	array(
 		'selectors' => array(
 			'wpmovies' => array(
@@ -147,7 +147,7 @@ In the `view.js` file, we add both the selector, which reads the post ID from th
 // render.php (simplified)
 // ...
 
-store(
+wp_store(
 	array(
 		'selectors' => array(
 			'wpmovies' => array(
@@ -262,7 +262,7 @@ In the `view.js`, we simply set the selectors that vary depending on the context
 <?php
 // Video Player
 // render.php (simplified)
-store(
+wp_store(
 	array(
 		'state'     => array(
 			'wpmovies' => array(
@@ -337,7 +337,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'movie-search' )
 );
 
-store(
+wp_store(
 	array(
 		'state' => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/likes-number/render.php
+++ b/src/blocks/interactive/likes-number/render.php
@@ -3,7 +3,7 @@ $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 $likedMovies				= array();
 
-store(
+wp_store(
 	array(
 		'state'     => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/movie-like-button/render.php
+++ b/src/blocks/interactive/movie-like-button/render.php
@@ -3,7 +3,7 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-store(
+wp_store(
 	array(
 		'selectors' => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/movie-like-icon/render.php
+++ b/src/blocks/interactive/movie-like-icon/render.php
@@ -3,7 +3,7 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-store(
+wp_store(
 	array(
 		'selectors' => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/movie-search/render.php
+++ b/src/blocks/interactive/movie-search/render.php
@@ -3,7 +3,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'movie-search' )
 );
 
-store(
+wp_store(
 	array(
 		'state' => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/movie-tabs/render.php
+++ b/src/blocks/interactive/movie-tabs/render.php
@@ -6,7 +6,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 $images             = get_post_meta( $post->ID, '_wpmovies_images', true );
 $videos             = get_post_meta( $post->ID, '_wpmovies_videos', true );
 
-store(
+wp_store(
 	array(
 		'selectors' => array(
 			'wpmovies' => array(

--- a/src/blocks/interactive/video-player/render.php
+++ b/src/blocks/interactive/video-player/render.php
@@ -3,7 +3,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'wpmovies-video-player' )
 );
 
-store(
+wp_store(
 	array(
 		'state'     => array(
 			'wpmovies' => array(


### PR DESCRIPTION
⚠️ _Don't merge until [this pull request](https://github.com/WordPress/block-interactivity-experiments/pull/190) from the block-interactivity-experiments repo is merged._

As decided [here](https://github.com/WordPress/block-interactivity-experiments/issues/136#issuecomment-1463944790), the Interactivity API will use `wp_store()` instead of `store()` for the PHP files. Once [this pull request to make that change](https://github.com/WordPress/block-interactivity-experiments/pull/190) is merged, we need to modify the blocks code to use `wp_store()`.