### PR TITLE
Disable the browser autocompletion

### DIFF
--- a/src/blocks/interactive/movie-search/render.php
+++ b/src/blocks/interactive/movie-search/render.php
@@ -21,6 +21,7 @@ store(
 		inputmode="search"
 		placeholder="Search for a movie..."
 		required=""
+		autocomplete="off"
 		data-wp-bind.value="state.wpmovies.searchValue"
 		data-wp-on.input="actions.wpmovies.updateSearch"
 	>


### PR DESCRIPTION
With the browser autocomplete I get those weird autocompletions that are not appropriate for the Search block:

<img width="551" alt="Screenshot 2023-03-23 at 13 33 38" src="https://user-images.githubusercontent.com/5417266/227315033-0c70ddd4-089e-41b4-a431-494a6002edd3.png">
