### PR TITLE
Add a link to the WP movies repo in footer

### DIFF
--- a/wp-movies-theme/parts/footer.html
+++ b/wp-movies-theme/parts/footer.html
@@ -4,9 +4,15 @@
 <p class="has-text-align-center">Proudly Powered by <a href="https://wordpress.org" data-id="wordpress.org">WordPress</a>.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"align":"center"} -->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center">Data provided by&nbsp;<a rel="noreferrer noopener" href="https://www.themoviedb.org/" target="_blank">TMDB</a>.</p>
 <!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Code for this demo is <a href="https://github.com/WordPress/wp-movies-demo">on GitHub</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:wpmovies/video-player /--></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
Added the "Code for this demo is [on GitHub](https://github.com/WordPress/wp-movies-demo/)"

<img width="537" alt="Screenshot 2023-03-24 at 15 35 20" src="https://user-images.githubusercontent.com/5417266/227634216-cf8330c1-5f35-47d0-8b91-67669095805d.png">
