### PR TITLE
Change directives suffix to double hyphen instead of dot

### DIFF
--- a/docs/interactive-blocks/README.md
+++ b/docs/interactive-blocks/README.md
@@ -30,7 +30,7 @@ wp_store(
 
 <div
 	<?php echo $wrapper_attributes; ?>
-	data-wp-class.wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty"
+	data-wp-class--wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty"
 >
 	<?php echo $play_icon; ?>
 	<span data-wp-text="selectors.wpmovies.likesCount"></span>
@@ -90,11 +90,11 @@ wp_store(
 >
 	<div
 		class="wpmovies-page-button-parent"
-		data-wp-on.click="actions.wpmovies.toggleMovie"
+		data-wp-on--click="actions.wpmovies.toggleMovie"
 	>
 		<div
 			class="wpmovies-page-button-child"
-			data-wp-class.wpmovies-liked="selectors.wpmovies.isMovieIncluded"
+			data-wp-class--wpmovies-liked="selectors.wpmovies.isMovieIncluded"
 		>
 			<?php echo $play_icon; ?>
 			<span>
@@ -165,14 +165,14 @@ wp_store(
 >
 	<ul>
 		<li
-			data-wp-on.click="actions.wpmovies.showImagesTab"
-			data-wp-class.wpmovies-active-tab="selectors.wpmovies.isImagesTab"
+			data-wp-on--click="actions.wpmovies.showImagesTab"
+			data-wp-class--wpmovies-active-tab="selectors.wpmovies.isImagesTab"
 		>
 				Images
 			</li>
 		<li
-			data-wp-on.click="actions.wpmovies.showVideosTab"
-			data-wp-class.wpmovies-active-tab="selectors.wpmovies.isVideosTab"
+			data-wp-on--click="actions.wpmovies.showVideosTab"
+			data-wp-class--wpmovies-active-tab="selectors.wpmovies.isVideosTab"
 		>
 				Videos
 			</li>
@@ -198,7 +198,7 @@ wp_store(
 				$video_id = substr( $video['url'], strpos( $video['url'], '?v=' ) + 3 );
 				?>
 				<div class="wpmovies-tabs-video-wrapper" data-wp-context='{ "videoId": "<?php echo $video_id; ?>" }'>
-					<div data-wp-on.click="actions.wpmovies.setVideo"><svg ...></div>
+					<div data-wp-on--click="actions.wpmovies.setVideo"><svg ...></div>
 					<img src="<?php echo 'https://img.youtube.com/vi/' . $video_id . '/0.jpg'; ?>">
 				</div>
 				<?php
@@ -250,7 +250,7 @@ In the `view.js`, we simply set the selectors that vary depending on the context
 // Movie Trailer Button
 // render.php (simplified)
 <div <?php echo $wrapper_attributes; ?> data-wp-context='{ "videoId": "<?php echo $trailer_id; ?>" }'>
-	<div class="wpmovies-page-button-parent" data-wp-on.click="actions.wpmovies.setVideo">
+	<div class="wpmovies-page-button-parent" data-wp-on--click="actions.wpmovies.setVideo">
 		<div class="wpmovies-page-button-child">
 			<?php echo $play_icon; ?><span>Play trailer</span>
 		</div>
@@ -281,7 +281,7 @@ wp_store(
 <div data-wp-show="selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>
 	<div class="wpmovies-video-wrapper">
 		<div class="wpmovies-video-close">
-			<button class="close-button" data-wp-on.click="actions.wpmovies.closeVideo">
+			<button class="close-button" data-wp-on--click="actions.wpmovies.closeVideo">
 				<?php _e( 'Close' ); ?>
 			</button>
 		</div>
@@ -355,8 +355,8 @@ wp_store(
 	  inputmode="search"
 	  placeholder="Search for a movie..."
 		required=""
-		data-wp-bind.value="state.wpmovies.searchValue"
-		data-wp-on.input="actions.wpmovies.updateSearch"
+		data-wp-bind--value="state.wpmovies.searchValue"
+		data-wp-on--input="actions.wpmovies.updateSearch"
 	>
 </div>
 ```

--- a/src/blocks/interactive/likes-number/render.php
+++ b/src/blocks/interactive/likes-number/render.php
@@ -22,7 +22,7 @@ wp_store(
 
 <div 
 	<?php echo $wrapper_attributes; ?>
-	data-wp-class.wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty">
+	data-wp-class--wpmovies-liked="selectors.wpmovies.isLikedMoviesNotEmpty">
 	<?php echo $play_icon; ?>
 	<span data-wp-text="selectors.wpmovies.likesCount"></span>
 </div>

--- a/src/blocks/interactive/movie-like-button/render.php
+++ b/src/blocks/interactive/movie-like-button/render.php
@@ -20,11 +20,11 @@ wp_store(
 >
 	<div
 		class="wpmovies-page-button-parent"
-		data-wp-on.click="actions.wpmovies.toggleMovie"
+		data-wp-on--click="actions.wpmovies.toggleMovie"
 	>
 		<div
 			class="wpmovies-page-button-child"
-			data-wp-class.wpmovies-liked="selectors.wpmovies.isMovieIncluded"
+			data-wp-class--wpmovies-liked="selectors.wpmovies.isMovieIncluded"
 		>
 			<?php echo $play_icon; ?>
 			<span>

--- a/src/blocks/interactive/movie-like-icon/render.php
+++ b/src/blocks/interactive/movie-like-icon/render.php
@@ -19,8 +19,8 @@ wp_store(
 	data-wp-context='{ "post": { "id": <?php echo $post->ID; ?> } }'
 >
 	<div
-		data-wp-on.click="actions.wpmovies.toggleMovie"
-		data-wp-class.wpmovies-liked="selectors.wpmovies.isMovieIncluded"
+		data-wp-on--click="actions.wpmovies.toggleMovie"
+		data-wp-class--wpmovies-liked="selectors.wpmovies.isMovieIncluded"
 	>
 		<?php echo $play_icon; ?>
 	</div>

--- a/src/blocks/interactive/movie-search/render.php
+++ b/src/blocks/interactive/movie-search/render.php
@@ -26,8 +26,8 @@ wp_store(
 			placeholder="Search for a movie..."
 			required=""
 			autocomplete="off"
-			data-wp-bind.value="state.wpmovies.searchValue"
-			data-wp-on.input="actions.wpmovies.updateSearch"
+			data-wp-bind--value="state.wpmovies.searchValue"
+			data-wp-on--input="actions.wpmovies.updateSearch"
 			>
 	</form>
 </div>

--- a/src/blocks/interactive/movie-tabs/render.php
+++ b/src/blocks/interactive/movie-tabs/render.php
@@ -26,9 +26,9 @@ wp_store(
 		<li class="wpmovies-tabs-title">
 			<button
 				id="wpmovies-images-tab"
-				data-wp-on.click="actions.wpmovies.showImagesTab"
-				data-wp-class.wpmovies-active-tab="selectors.wpmovies.isImagesTab"
-				data-wp-bind.aria-selected="selectors.wpmovies.isImagesTab"
+				data-wp-on--click="actions.wpmovies.showImagesTab"
+				data-wp-class--wpmovies-active-tab="selectors.wpmovies.isImagesTab"
+				data-wp-bind--aria-selected="selectors.wpmovies.isImagesTab"
 				role="tab"
 				class="wpmovies-tab-button"
 			>
@@ -38,9 +38,9 @@ wp_store(
 		<li class="wpmovies-tabs-title">
 			<button
 				id="wpmovies-videos-tab"
-				data-wp-on.click="actions.wpmovies.showVideosTab"
-				data-wp-class.wpmovies-active-tab="selectors.wpmovies.isVideosTab"
-				data-wp-bind.aria-selected="selectors.wpmovies.isVideosTab"
+				data-wp-on--click="actions.wpmovies.showVideosTab"
+				data-wp-class--wpmovies-active-tab="selectors.wpmovies.isVideosTab"
+				data-wp-bind--aria-selected="selectors.wpmovies.isVideosTab"
 				role="tab"
 				class="wpmovies-tab-button"
 			>
@@ -52,7 +52,7 @@ wp_store(
 	<div 
 		role="tabpanel" 
 		data-wp-show="selectors.wpmovies.isImagesTab" 
-		data-wp-bind.aria-hidden="selectors.wpmovies.isVideosTab" 
+		data-wp-bind--aria-hidden="selectors.wpmovies.isVideosTab" 
 		aria-labelledby="wpmovies-images-tab"
 	>
 		<div class="wpmovies-media-scroller wpmovies-images-tab">
@@ -70,7 +70,7 @@ wp_store(
 	<div 
 		role="tabpanel" 
 		data-wp-show="selectors.wpmovies.isVideosTab" 
-		data-wp-bind.aria-hidden="selectors.wpmovies.isImagesTab" 
+		data-wp-bind--aria-hidden="selectors.wpmovies.isImagesTab" 
 		aria-labelledby="wpmovies-videos-tab"
 	>
 		<div class="wpmovies-media-scroller wpmovies-videos-tab">
@@ -79,7 +79,7 @@ wp_store(
 				$video_id = substr( $video['url'], strpos( $video['url'], '?v=' ) + 3 );
 				?>
 				<div class="wpmovies-tabs-video-wrapper" data-wp-context='{ "videoId": "<?php echo $video_id; ?>" }'>
-					<div data-wp-on.click="actions.wpmovies.setVideo" aria-controls="wp-movies-video-player">
+					<div data-wp-on--click="actions.wpmovies.setVideo" aria-controls="wp-movies-video-player">
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ffffff" class="play-icon">
 							<path d="M3 22v-20l18 10-18 10z" />
 						</svg>

--- a/src/blocks/interactive/movie-trailer-button/render.php
+++ b/src/blocks/interactive/movie-trailer-button/render.php
@@ -19,7 +19,7 @@ if ( count( $trailers ) !== 0 ) {
 	?>
 
 	<div <?php echo $wrapper_attributes; ?> data-wp-context='<?php echo esc_attr( wp_json_encode( array( 'videoId' => $trailer_id ) ) ); ?>'>
-		<div class="wpmovies-page-button-parent" data-wp-on.click="actions.wpmovies.setVideo" aria-controls="wp-movies-video-player">
+		<div class="wpmovies-page-button-parent" data-wp-on--click="actions.wpmovies.setVideo" aria-controls="wp-movies-video-player">
 			<div class="wpmovies-page-button-child">
 				<?php echo $play_icon; ?><span>Play trailer</span>
 			</div>

--- a/src/blocks/interactive/video-player/render.php
+++ b/src/blocks/interactive/video-player/render.php
@@ -22,7 +22,7 @@ wp_store(
 <div id="wp-movies-video-player" data-wp-show="selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>
 	<div class="wpmovies-video-wrapper">
 		<div class="wpmovies-video-close">
-			<button class="close-button" data-wp-on.click="actions.wpmovies.closeVideo">
+			<button class="close-button" data-wp-on--click="actions.wpmovies.closeVideo">
 				<?php _e( 'Close' ); ?>
 			</button>
 		</div>
@@ -31,7 +31,7 @@ wp_store(
 			height="315"
 			allow="autoplay"
 			allowfullscreen
-			data-wp-bind.src="state.wpmovies.currentVideo"
+			data-wp-bind--src="state.wpmovies.currentVideo"
 		></iframe>
 	</div>
 </div>


### PR DESCRIPTION
## What?

I updated the current blocks to match [the changes made in the Block Interactivity Experiments repo](https://github.com/WordPress/block-interactivity-experiments/pull/239).


## Why?
In the Block Interactivity Experiments repo, these changes were made because:

1. JSX doesn't support attributes with dots in them.
2. The term island has no meaning in WordPress, and we don't intend to embrace it.

## How?

* Change the directives to use `data-wp-on--` instead of the dot.