### PR TITLE
Movie Like Icon: Use empty-heart.svg in editor

### DIFF
--- a/src/blocks/interactive/movie-like-icon/edit.js
+++ b/src/blocks/interactive/movie-like-icon/edit.js
@@ -1,16 +1,11 @@
 import '@wordpress/block-editor';
 import { useBlockProps } from '@wordpress/block-editor';
+import { ReactComponent as EmptyHeart } from '../../../../wp-movies-theme/assets/empty-heart.svg';
 
 const Edit = () => {
 	return (
 		<div {...useBlockProps()}>
-			<img
-				draggable="false"
-				role="img"
-				className="emoji"
-				alt=":heart:"
-				src="https://s.w.org/images/core/emoji/14.0.0/svg/2764.svg"
-			/>
+			<EmptyHeart />
 		</div>
 	);
 };

--- a/src/blocks/interactive/movie-like-icon/style.css
+++ b/src/blocks/interactive/movie-like-icon/style.css
@@ -4,7 +4,7 @@
 	padding-top: 8px;
 }
 
-.wp-block-wpmovies-movie-like-icon > div:not(.wpmovies-liked) svg > path {
+.wp-block-wpmovies-movie-like-icon svg > path {
 	fill: #999999;
 	stroke-width: 0;
 }

--- a/wp-movies-theme/style.css
+++ b/wp-movies-theme/style.css
@@ -92,12 +92,9 @@ header > div.wp-block-group {
 	margin-right: 14px;
 }
 
-.wpmovies-liked svg {
-	fill: #dc3e3e;
-}
-
-.wpmovies-liked svg > path {
+.wpmovies-liked > svg > path {
 	stroke-width: 0;
+	fill: #dc3e3e;
 }
 
 @media screen and (max-width: 900px) {


### PR DESCRIPTION
Some minor tweaks to the Like Icon.

Thanks to the way that webpack is set up in `@wordpress/scripts`, [we can use a pseudo-import from SVG as follows](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#using-svg):

```js
import { ReactComponent as EmptyHeart } from '../../../../wp-movies-theme/assets/empty-heart.svg';
```

This allows us to render the included SVG asset in the editor, rather than the external SVG at https://s.w.org/images/core/emoji/14.0.0/svg/2764.svg -- thus giving us better visual parity between editor and frontend.

As a follow-up, we could make a similar change to other blocks that include the heart SVG.

| | Before | After |
|-|-------|-------|
| Editor | ![image](https://github.com/WordPress/wp-movies-demo/assets/96308/765f242e-6a27-4201-b91b-4235cb65b314) | ![image](https://github.com/WordPress/wp-movies-demo/assets/96308/751748d0-9948-4046-b7f4-c4911dfd9a64) | 
| Frontend | ![image](https://github.com/WordPress/wp-movies-demo/assets/96308/449504f8-15bd-4f36-8ab6-bdc14d72db07) | ![image](https://github.com/WordPress/wp-movies-demo/assets/96308/bf0e900e-cbec-402e-b665-e9f337bab5af) |

Discovered while working on https://github.com/ockham/like-button (which is basically stolen from the Movies Like Button).