### PR TITLE
Fix: Move wp_store() to wp_initial_state()

### DIFF
--- a/docs/interactive-blocks/README.md
+++ b/docs/interactive-blocks/README.md
@@ -11,21 +11,11 @@ $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 $likedMovies        = array();
 
-wp_store(
-	array(
-		'state' => array(
-			'wpmovies' => array(
-				'likedMovies' => $likedMovies,
-			),
-		),
-		'selectors' => array(
-			'wpmovies' => array(
-				'likesCount'            => count( $likedMovies ),
-				'isLikedMoviesNotEmpty' => count( $likedMovies ) > 0,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'likedMovies' => $likedMovies,
+	'likesCount'            => count( $likedMovies ),
+	'isLikedMoviesNotEmpty' => count( $likedMovies ) > 0,
+));
 ?>
 
 <div
@@ -73,15 +63,10 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-wp_store(
-	array(
-		'selectors' => array(
-			'wpmovies' => array(
-				'isMovieIncluded' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'isMovieIncluded' => false,
+));
+
 ?>
 
 <div
@@ -147,16 +132,10 @@ In the `view.js` file, we add both the selector, which reads the post ID from th
 // render.php (simplified)
 // ...
 
-wp_store(
-	array(
-		'selectors' => array(
-			'wpmovies' => array(
-				'isImagesTab' => true,
-				'isVideosTab' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'isImagesTab' => true,
+	'isVideosTab' => false,
+));
 ?>
 
 <div
@@ -262,20 +241,11 @@ In the `view.js`, we simply set the selectors that vary depending on the context
 <?php
 // Video Player
 // render.php (simplified)
-wp_store(
-	array(
-		'state'     => array(
-			'wpmovies' => array(
-				'currentVideo' => '',
-			),
-		),
-		'selectors' => array(
-			'wpmovies' => array(
-				'isPlaying' => false,
-			),
-		),
-	),
-);
+
+wp_initial_state('wpmovies', array(
+	'isPlaying' => false,
+	'currentVideo' => '',
+));
 ?>
 
 <div data-wp-show="selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>
@@ -337,15 +307,9 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'movie-search' )
 );
 
-wp_store(
-	array(
-		'state' => array(
-			'wpmovies' => array(
-				'searchValue' => get_search_query(),
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'searchValue' => get_search_query(),
+));
 ?>
 
 <div <?php echo $wrapper_attributes; ?>>

--- a/src/blocks/interactive/likes-number/render.php
+++ b/src/blocks/interactive/likes-number/render.php
@@ -3,21 +3,11 @@ $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 $likedMovies				= array();
 
-wp_store(
-	array(
-		'state'     => array(
-			'wpmovies' => array(
-				'likedMovies' => $likedMovies,
-			),
-		),
-		'selectors' => array(
-			'wpmovies' => array(
-				'likesCount'            => count( $likedMovies ),
-				'isLikedMoviesNotEmpty' => count( $likedMovies ) > 0,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'likedMovies' => $likedMovies,
+	'likesCount'            => count( $likedMovies ),
+	'isLikedMoviesNotEmpty' => count( $likedMovies ) > 0,
+));
 ?>
 
 <div 

--- a/src/blocks/interactive/movie-like-button/render.php
+++ b/src/blocks/interactive/movie-like-button/render.php
@@ -3,15 +3,9 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-wp_store(
-	array(
-		'selectors' => array(
-			'wpmovies' => array(
-				'isMovieIncluded' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'isMovieIncluded' => false,
+));
 ?>
 
 <div

--- a/src/blocks/interactive/movie-like-icon/render.php
+++ b/src/blocks/interactive/movie-like-icon/render.php
@@ -3,15 +3,9 @@ $post               = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $play_icon          = file_get_contents( get_template_directory() . '/assets/empty-heart.svg' );
 
-wp_store(
-	array(
-		'selectors' => array(
-			'wpmovies' => array(
-				'isMovieIncluded' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'isMovieIncluded' => false,
+));
 ?>
 
 <div

--- a/src/blocks/interactive/movie-search/render.php
+++ b/src/blocks/interactive/movie-search/render.php
@@ -3,15 +3,9 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'movie-search' )
 );
 
-wp_store(
-	array(
-		'state' => array(
-			'wpmovies' => array(
-				'searchValue' => get_search_query(),
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'searchValue' => get_search_query(),
+));
 ?>
 
 <div <?php echo $wrapper_attributes; ?>>

--- a/src/blocks/interactive/movie-tabs/render.php
+++ b/src/blocks/interactive/movie-tabs/render.php
@@ -7,16 +7,10 @@ $wrapper_attributes = get_block_wrapper_attributes(
 $images = json_decode( get_post_meta( $post->ID, '_wpmovies_images', true ), true );
 $videos = json_decode( get_post_meta( $post->ID, '_wpmovies_videos', true ), true );
 
-wp_store(
-	array(
-		'selectors' => array(
-			'wpmovies' => array(
-				'isImagesTab' => true,
-				'isVideosTab' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'isImagesTab' => true,
+	'isVideosTab' => false,
+));
 ?>
 
 <div

--- a/src/blocks/interactive/video-player/render.php
+++ b/src/blocks/interactive/video-player/render.php
@@ -3,20 +3,10 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	array( 'class' => 'wpmovies-video-player' )
 );
 
-wp_store(
-	array(
-		'state'     => array(
-			'wpmovies' => array(
-				'currentVideo' => '',
-			),
-		),
-		'selectors' => array(
-			'wpmovies' => array(
-				'isPlaying' => false,
-			),
-		),
-	),
-);
+wp_initial_state('wpmovies', array(
+	'currentVideo' => '',
+	'isPlaying' => false,
+));
 ?>
 
 <div id="wp-movies-video-player" data-wp-bind--hidden="!selectors.wpmovies.isPlaying" <?php echo $wrapper_attributes; ?>>


### PR DESCRIPTION
With the last Gutenberg update (G 17.5.0. The Interactivity API server rendering switched from `wp_store` to `wp_initial_state`. A much shorter way to declare initial state.

That crashed  `wpmovies.dev`, with the Fatal Error: called to undefined function `wp_store`. It has been fixed on production, but this PR should be updated as soon as possible.