### PR TITLE
Deactivate plugin when Gutenberg is not installed and activated

### DIFF
--- a/wpmovies.php
+++ b/wpmovies.php
@@ -30,7 +30,7 @@ if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 				'<div class="error"><p>%s</p></div>',
 				__(
 					'WP Movies plugin requires the Gutenberg plugin to be installed and activated.',
-					'wp-directives'
+					'wp-movies-demo'
 				)
 			);
 		}

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -22,6 +22,23 @@ if ( ! function_exists( 'is_plugin_active' ) ) {
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 }
 
+if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+	add_action(
+		'admin_notices',
+		function () {
+			echo sprintf(
+				'<div class="error"><p>%s</p></div>',
+				__(
+					'WP Movies plugin requires the Gutenberg plugin to be installed and activated.',
+					'wp-directives'
+				)
+			);
+		}
+	);
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+	return;
+}
+
 add_action( 'init', 'auto_register_block_types' );
 
 /**

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -9,35 +9,13 @@
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       wp-movies-demo
+ * Requires Plugins:  gutenberg
  */
 
 require_once __DIR__ . '/lib/custom-post-types.php';
 require_once __DIR__ . '/lib/custom-taxonomies.php';
 require_once __DIR__ . '/lib/custom-query-block.php';
 require_once __DIR__ . '/lib/db-update/index.php';
-
-
-// Check if Gutenberg plugin is active.
-if ( ! function_exists( 'is_plugin_active' ) ) {
-	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-}
-
-if ( ! is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-	add_action(
-		'admin_notices',
-		function () {
-			echo sprintf(
-				'<div class="error"><p>%s</p></div>',
-				__(
-					'WP Movies plugin requires the Gutenberg plugin to be installed and activated.',
-					'wp-movies-demo'
-				)
-			);
-		}
-	);
-	deactivate_plugins( plugin_basename( __FILE__ ) );
-	return;
-}
 
 add_action( 'init', 'auto_register_block_types' );
 


### PR DESCRIPTION
Even though there is actually a comment in the code saying we check if Gutenberg is installed, we are not really doing it. This pull request adds that check and triggers an admin notice when Gutenberg is deactivated.