### PR TITLE
style.css: Remove duplicate border property

### DIFF
--- a/src/blocks/interactive/movie-search/style.css
+++ b/src/blocks/interactive/movie-search/style.css
@@ -21,7 +21,6 @@
 .wp-block-wpmovies-movie-search input:focus-visible {
 	color: var(--wp--preset--color--white);
 	background-color: #181818;
-	border: 1px solid rgba(255, 255, 255, 0.07);
 	border-radius: 3px;
 	border: none;
 	padding: 12px;


### PR DESCRIPTION
Found through a linter when using this file in a different project.

Per the CSS spec, if a rule is duplicated, it's the last occurrence that's applied, so I'm removing the first one.