### PR TITLE
Prevent fatals if post_meta is null.

### DIFF
--- a/src/blocks/interactive/movie-trailer-button/render.php
+++ b/src/blocks/interactive/movie-trailer-button/render.php
@@ -14,36 +14,38 @@ $play_icon = file_get_contents( get_template_directory() . '/assets/play.svg' );
 $videos    = get_post_meta( $post->ID, 'wpmovies_videos', true );
 $trailers  = array();
 
-if ( $videos ) {
-	$trailers = array_filter(
-		json_decode( $videos, true ) ?: array(),
-		function( $video ) {
-			return isset( $video['type'] ) && 'Trailer' === $video['type'];
-		}
-	);
+if ( ! $videos ) {
+	return;
 }
 
+$trailers = array_filter(
+	json_decode( $videos, true ) ?: array(),
+	function( $video ) {
+		return isset( $video['type'] ) && 'Trailer' === $video['type'];
+	}
+);
+
 if ( $trailers && count( $trailers ) !== 0 ) {
-	 $trailer_url = reset( $trailers )['url'];
-	 $trailer_id  = substr( $trailer_url, strpos( $trailer_url, '?v=' ) + 3 );
-	 $context     = array( 'videoId' => $trailer_id );
+		$trailer_url = reset( $trailers )['url'];
+		$trailer_id  = substr( $trailer_url, strpos( $trailer_url, '?v=' ) + 3 );
+		$context     = array( 'videoId' => $trailer_id );
 	?>
 
+<div
+	data-wp-interactive="wpmovies"
+	<?php echo $wrapper_attributes; ?>
+	<?php echo wp_interactivity_data_wp_context( $context ); ?>
+>
 	<div
-		data-wp-interactive="wpmovies"
-		<?php echo $wrapper_attributes; ?>
-		<?php echo wp_interactivity_data_wp_context( $context ); ?>
+		class="wpmovies-page-button-parent"
+		data-wp-on--click="actions.setVideo"
+		aria-controls="wp-movies-video-player"
 	>
-		<div
-			class="wpmovies-page-button-parent"
-			data-wp-on--click="actions.setVideo"
-			aria-controls="wp-movies-video-player"
-		>
-			<div class="wpmovies-page-button-child">
-				<?php echo $play_icon; ?>
-				<span><?php _e( 'Play trailer', 'wpmovies' ); ?></span>
-			</div>
+		<div class="wpmovies-page-button-child">
+			<?php echo $play_icon; ?>
+			<span><?php _e( 'Play trailer', 'wpmovies' ); ?></span>
 		</div>
 	</div>
+</div>
 
 <?php } ?>

--- a/src/blocks/interactive/movie-trailer-button/render.php
+++ b/src/blocks/interactive/movie-trailer-button/render.php
@@ -12,7 +12,6 @@ $wrapper_attributes = get_block_wrapper_attributes(
 $post      = get_post();
 $play_icon = file_get_contents( get_template_directory() . '/assets/play.svg' );
 $videos    = get_post_meta( $post->ID, 'wpmovies_videos', true );
-$trailers  = array();
 
 if ( ! $videos ) {
 	return;

--- a/src/blocks/interactive/movie-trailer-button/render.php
+++ b/src/blocks/interactive/movie-trailer-button/render.php
@@ -12,17 +12,21 @@ $wrapper_attributes = get_block_wrapper_attributes(
 $post      = get_post();
 $play_icon = file_get_contents( get_template_directory() . '/assets/play.svg' );
 $videos    = get_post_meta( $post->ID, 'wpmovies_videos', true );
-$trailers  = array_filter(
-	json_decode( $videos, true ),
-	function( $video ) {
-		return 'Trailer' === $video['type'];
-	}
-);
+$trailers  = array();
 
-if ( count( $trailers ) !== 0 ) {
-	$trailer_url = reset( $trailers )['url'];
-	$trailer_id  = substr( $trailer_url, strpos( $trailer_url, '?v=' ) + 3 );
-	$context     = array( 'videoId' => $trailer_id );
+if ( $videos ) {
+	$trailers = array_filter(
+		json_decode( $videos, true ) ?: array(),
+		function( $video ) {
+			return isset( $video['type'] ) && 'Trailer' === $video['type'];
+		}
+	);
+}
+
+if ( $trailers && count( $trailers ) !== 0 ) {
+	 $trailer_url = reset( $trailers )['url'];
+	 $trailer_id  = substr( $trailer_url, strpos( $trailer_url, '?v=' ) + 3 );
+	 $context     = array( 'videoId' => $trailer_id );
 	?>
 
 	<div
@@ -37,7 +41,7 @@ if ( count( $trailers ) !== 0 ) {
 		>
 			<div class="wpmovies-page-button-child">
 				<?php echo $play_icon; ?>
-				<span>Play trailer</span>
+				<span><?php _e( 'Play trailer', 'wpmovies' ); ?></span>
 			</div>
 		</div>
 	</div>

--- a/src/blocks/non-interactive/movie-score/render.php
+++ b/src/blocks/non-interactive/movie-score/render.php
@@ -12,7 +12,7 @@
  $score_color = '#5EFD26'; // Green.
 
 if ( $score === null ) {
-	$score_color = '#808080'; // Gray for no score
+	$score_color = '#808080'; // Gray for no score.
 	$degrees_css = 0;
 } else {
 	if ( $score < 7 && $score >= 3 ) {

--- a/src/blocks/non-interactive/movie-score/render.php
+++ b/src/blocks/non-interactive/movie-score/render.php
@@ -5,15 +5,23 @@
  * @package wpmovies
  */
 
-$post        = get_post();
-$score       = get_post_meta( $post->ID, 'wpmovies_vote_average', true );
-$score_color = '#5EFD26'; // Green.
-if ( $score < 7 && $score >= 3 ) {
-	$score_color = '#fad900'; // Yellow.
-} elseif ( $score < 3 ) {
-	$score_color = '#de1600'; // Red.
-};
-$degrees_css = $score * 180 / 10;
+
+ $post        = get_post();
+ $score       = get_post_meta( $post->ID, 'wpmovies_vote_average', true );
+ $score       = $score !== '' ? floatval( $score ) : null;
+ $score_color = '#5EFD26'; // Green.
+
+if ( $score === null ) {
+	$score_color = '#808080'; // Gray for no score
+	$degrees_css = 0;
+} else {
+	if ( $score < 7 && $score >= 3 ) {
+		$score_color = '#fad900'; // Yellow.
+	} elseif ( $score < 3 ) {
+		$score_color = '#de1600'; // Red.
+	}
+	$degrees_css = $score * 180 / 10;
+}
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
@@ -22,17 +30,17 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	)
 );
 ?>
-
-<div <?php echo $wrapper_attributes; ?>>
-	<div class="wpmovies-score-circle">
-		<div class="wpmovies-score-mask wpmovies-score-full" <?php echo 'style="transform: rotate(' . $degrees_css . 'deg)"'; ?>>
-			<div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"'; ?>></div>
-		</div>
-		<div class="wpmovies-score-mask wpmovies-score-half">
-			<div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"'; ?>></div>
-		</div>
-		<div class="wpmovies-score-inside-circle">
-			<span><?php echo round( $score * 10 ) . '%'; ?></span>
-		</div>
-	</div>
-</div>
+ 
+ <div <?php echo $wrapper_attributes; ?>>
+	 <div class="wpmovies-score-circle">
+		 <div class="wpmovies-score-mask wpmovies-score-full" <?php echo 'style="transform: rotate(' . $degrees_css . 'deg)"'; ?>>
+			 <div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"'; ?>></div>
+		 </div>
+		 <div class="wpmovies-score-mask wpmovies-score-half">
+			 <div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"'; ?>></div>
+		 </div>
+		 <div class="wpmovies-score-inside-circle">
+			 <span><?php echo round( $score * 10 ) . '%'; ?></span>
+		 </div>
+	 </div>
+ </div>


### PR DESCRIPTION
Due to cache issues on the site db. We had a couple of fatals while trying to do `array_filter` over a null value.
This quick PR prevents those.

Many custom blocks like these will be soon moved to block bindings.